### PR TITLE
Fix dependency installation with modern Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ bash setup_env.sh
 ```
 This installs the packages listed in `requirements.txt`.
 
+The package versions have been updated for **Python 3.11+**. If you
+need GPU support with `torch`, note that installation can be heavy.
+The optional `trixi` dependency is pinned to an old version and may
+require Python 3.8 or earlier.
+
 2) Activate the environment before running any experiments:
 
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-numpy==1.18.1
-pandas==0.24.2
-scipy==1.4.1
-torch==1.5.0
-trixi==0.1.2.2
-scikit-learn==0.20.2
-captum==0.2.0
-shap==0.35.0
+numpy>=2.2
+pandas>=2.3
+scipy>=1.15
+torch>=2.7
+# trixi requires legacy Python and is optional for preprocessing
+# trixi==0.1.2.2
+scikit-learn>=1.7
+captum>=0.8
+shap>=0.47
 pytest>=7.0


### PR DESCRIPTION
## Summary
- update requirements to recent versions compatible with Python 3.11
- clarify environment requirements in the README
- restrict pytest discovery to `tests/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c79b74a48322aaee6100e18514ce