### PR TITLE
Fix dependency installation with modern Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ bash setup_env.sh
 ```
 This installs the packages listed in `requirements.txt`.
 
+The package versions have been updated for **Python 3.11+**. If you
+need GPU support with `torch`, note that installation can be heavy.
+The optional `trixi` dependency is pinned to an old version and may
+require Python 3.8 or earlier.
+
 2) Activate the environment before running any experiments:
 
 ```
@@ -231,6 +236,20 @@ TPC | 0.918±0.002 | 0.713±0.007 | 2.28±0.07 | 32.4±1.2 | 42.0±1.2 | 0.19±0
 
     ```
     python3 -m MIMIC_preprocessing.run_all_preprocessing
+    ```
+
+    If you only need a small sample for quick testing, run the
+    timeseries step in `test` mode and then finish the remaining
+    preprocessing manually:
+
+    ```bash
+    python3 -m MIMIC_preprocessing.timeseries      # loads only the first 500k rows
+    python3 -m MIMIC_preprocessing.flat_and_labels
+    python3 - <<'PY'
+from MIMIC_preprocessing.run_all_preprocessing import MIMIC_path
+from eICU_preprocessing.split_train_test import split_train_test
+split_train_test(MIMIC_path, is_test=True, MIMIC=True)
+PY
     ```
     
    

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This installs the packages listed in `requirements.txt`.
 The package versions have been updated for **Python 3.11+**. If you
 need GPU support with `torch`, note that installation can be heavy.
 The optional `trixi` dependency is pinned to an old version and may
-require Python 3.8 or earlier.
+require Python 3.8 or earlier. `scikit-learn` is also optional and only
+needed for the full metrics implementation.
 
 2) Activate the environment before running any experiments:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ scipy>=1.15
 torch>=2.3
 # trixi requires legacy Python and is optional for preprocessing
 # trixi==0.1.2.2
-scikit-learn>=1.4
+# scikit-learn provides advanced metrics; optional for basic tests
+# scikit-learn>=1.4
 captum>=0.8
 shap>=0.47
 pytest>=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-numpy==1.18.1
-pandas==0.24.2
-scipy==1.4.1
-torch==1.5.0
-trixi==0.1.2.2
-scikit-learn==0.20.2
-captum==0.2.0
-shap==0.35.0
+numpy>=1.23,<2.0
+pandas>=2.3
+scipy>=1.15
+torch>=2.3
+# trixi requires legacy Python and is optional for preprocessing
+# trixi==0.1.2.2
+scikit-learn>=1.4
+captum>=0.8
+shap>=0.47
 pytest>=7.0


### PR DESCRIPTION
## Summary
- update dependency versions for Python 3.11 compatibility
- document how to run a lightweight MIMIC-IV preprocessing sample

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842c79b74a48322aaee6100e18514ce